### PR TITLE
change drawImage to putImageData

### DIFF
--- a/src/convnet_vol_util.js
+++ b/src/convnet_vol_util.js
@@ -57,7 +57,7 @@
 
     // due to a Firefox bug
     try {
-      ctx.drawImage(img, 0, 0);
+      ctx.putImageData(img, 0, 0);
     } catch (e) {
       if (e.name === "NS_ERROR_NOT_AVAILABLE") {
         // sometimes happens, lets just abort


### PR DESCRIPTION
since canvas.toDataURL does not work(no width and height), the parameter in img_to_vol will be canvas.getImageData() and if the entry parameter is getIMageData; drawIMage() can not work. so canvastoDataURL should not be used as the entry parameter